### PR TITLE
Fix missing include cstring to prevent build errors

### DIFF
--- a/cli/bmplugincreator.cpp
+++ b/cli/bmplugincreator.cpp
@@ -19,12 +19,10 @@
  */
 
 #include "bmplugincreator.h"
-
 #include <zlib.h>
-
 #include <sstream>
-
 #include "md5.h"
+#include <cstring>
 
 const char _szBMPluginMagic[] = "B1GPLUGIN100!";
 


### PR DESCRIPTION
its needed because it use the function memset. Otherwise its not possible to build the cli version. Also the program give already a hint:

BMPluginBuilder/cli/bmplugincreator.cpp:28:1: note: ‘memset’ is defined in header ‘<cstring>’; did you forget to ‘#include <cstring>’?
 27 | #include "md5.h"
  +++ |+#include <cstring>